### PR TITLE
Disable usage logging by default in container

### DIFF
--- a/backend_config.yaml
+++ b/backend_config.yaml
@@ -10,3 +10,7 @@ jupyter_host: ''
 #A blank token string means to re-generate the token on container launch.
 jupyter_use_token: True
 jupyter_token: ''
+
+#A blank token for usage logging disables usage logging
+usage_logging_dir: ''
+


### PR DESCRIPTION
The default value for 'usage_logging_dir' is '/usr/gapps/spot/logs' which makes it so we work in the lorenz case without a config file. This change is to update backend_config.yaml in the container to set 'usage_logging_dir' to blank to disable.