### PR TITLE
K8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@
 FROM jupyter/minimal-notebook
 USER root
 WORKDIR /usr/gapps/spot
-RUN sudo apt update 
-RUN sudo apt install -y --fix-missing make cmake g++ nodejs npm
-RUN sudo /opt/conda/bin/pip install pandas matplotlib
-run sudo /opt/conda/bin/pip3 install pyyaml graphframes
+RUN apt-get update
+RUN apt-get install -y --fix-missing make cmake g++ nodejs npm
+RUN /opt/conda/bin/pip3 install pandas matplotlib
+RUN /opt/conda/bin/pip3 install pyyaml graphframes
 RUN npm init -y
 COPY package*.json /usr/gapps/spot/
 RUN npm install express path express-session multer body-parser cookie-parser pug bcryptjs

--- a/runspot.sh
+++ b/runspot.sh
@@ -48,7 +48,7 @@ if [[ x$USE_JUPYTERHUB == "x" || x$USE_JUPYTERHUB == "xFalse" || x$USE_JUPYTERHU
       JUPYTER_BASE_URL_ARG=""
   fi
 
-  /opt/conda/bin/jupyter notebook --notebook-dir=/notebooks $JUPYTER_TOKEN_ARG $JUPYTER_PORT_ARG $JUPYTER_BASE_URbackL_ARG --NotebookApp.password="" --no-browser &
+  /opt/conda/bin/jupyter notebook --notebook-dir=/notebooks $JUPYTER_TOKEN_ARG $JUPYTER_PORT_ARG $JUPYTER_BASE_URL_ARG --NotebookApp.password="" --no-browser &
   JUPYTERPID=$!
   export JUPYTERSERVER=`/opt/conda/bin/jupyter --runtime-dir`/nbserver-$JUPYTERPID.json
 fi


### PR DESCRIPTION
Dockerfile cleanup and typo bugfix for JUPYTER_BASE_URL_ARG.
The use of "apt" produced a warning saying apt does not provide a stable api, causing build to fail.
Use pip3 consistently.
Remove use of sudo. This does not seem to be needed.
Fix typo on JUPYTER_BASE_URL_ARG which was preventing Jupyter from working when running behind a nginx proxy.
